### PR TITLE
Support for port numbers larger than 32767 (Issue #8)

### DIFF
--- a/ConnectionTester.cs
+++ b/ConnectionTester.cs
@@ -14,7 +14,7 @@ namespace QuickConnect
 
         public enum ConnectionStatus{Succes, TimeOut, DnsFailed, DnsTimeOut,Refused};
         public string Host { get; }
-        public short Port { get; }
+        public ushort Port { get; }
         public ConnectionTester(string UrlOrIp, string port = "")
         {
             if (CheckIfIP(UrlOrIp, out var hostFound, out var portFound))
@@ -95,7 +95,7 @@ namespace QuickConnect
                 return ConnectionStatus.DnsTimeOut;
             }
         }
-        private static bool CheckIfIP(string toCheck, out string host, out short port)
+        private static bool CheckIfIP(string toCheck, out string host, out ushort port)
         {
             host = "";
             port = PortLogic.UnsetPort;
@@ -115,7 +115,7 @@ namespace QuickConnect
             }
             return false;
         }
-        private static bool CheckIfURL(string toCheck, out string host, out short port)
+        private static bool CheckIfURL(string toCheck, out string host, out ushort port)
         {
             host = "";
             port = PortLogic.UnsetPort;

--- a/OutputPrinter.cs
+++ b/OutputPrinter.cs
@@ -4,7 +4,7 @@ namespace QuickConnect
 {
     internal class OutputPrinter
     {
-        public static void PrintLogEntry(ConnectionTester.ConnectionStatus status, string host, short port, string currentTime, string startTime = "")
+        public static void PrintLogEntry(ConnectionTester.ConnectionStatus status, string host, ushort port, string currentTime, string startTime = "")
         {
             PrintTime(currentTime, startTime);
             PrintHost(host, port);
@@ -44,7 +44,7 @@ namespace QuickConnect
                 Console.Write($"{startTime} - {currentTime} ");
             }
         }
-        private static void PrintHost(string host, short port)
+        private static void PrintHost(string host, ushort port)
         {
             Console.ResetColor();
             Console.Write($"Connecting to {host}:{port}");

--- a/PortLogic.cs
+++ b/PortLogic.cs
@@ -2,17 +2,17 @@
 {
     internal class PortLogic
     {
-        public const short UnsetPort = 0;
-        public static short StringToPort(string toConvert)
+        public const ushort UnsetPort = 0;
+        public static ushort StringToPort(string toConvert)
         {
-            short toReturn;
-            if (!short.TryParse(toConvert, out toReturn))
+            ushort toReturn;
+            if (!ushort.TryParse(toConvert, out toReturn))
             {
                 toReturn = DeteminePortByProtocol(toConvert);
             }
             return toReturn;
         }
-        public static short DeteminePortByProtocol(string protocol)
+        public static ushort DeteminePortByProtocol(string protocol)
         {
             switch (protocol.ToLower())
             {


### PR DESCRIPTION
Fixes issue #8 at its core: it uses `ushort` instead of `short` for all port numbers.