### PR TITLE
Feature/multi input support

### DIFF
--- a/src/Tring/ConnectionRequest.cs
+++ b/src/Tring/ConnectionRequest.cs
@@ -15,17 +15,50 @@
 //You should have received a copy of the GNU Lesser General Public License
 //along with Tring.If not, see<https://www.gnu.org/licenses/>.
 
+using System;
 using System.Net;
+using System.Text.RegularExpressions;
 
 namespace Tring
 {
     class ConnectionRequest
     {
+        private static readonly Regex SplitFormat = new Regex(@"^(?<host>.*):(?<port>\w+)$");
+
         public ConnectionRequest(IPAddress ip = null, int port = PortLogic.UnsetPort, string url = "")
         {
             Ip = ip;
             Url = url;
             Port = port;
+        }
+        public static ConnectionRequest Parse(string input)
+        {
+            ConnectionRequest request;
+            var match = SplitFormat.Match(input);
+            var uriCreated = Uri.TryCreate(input, UriKind.Absolute, out var uri);
+            if (uriCreated && !string.IsNullOrEmpty(uri.DnsSafeHost))
+            {
+                request = new ConnectionRequest(null, uri.Port, uri.DnsSafeHost);
+            }
+            else if (match.Success)
+            {
+                var host = match.Groups["host"].Value;
+                var port = match.Groups["port"].Value;
+                var convertedPort = PortLogic.StringToPort(port);
+                if (convertedPort == PortLogic.UnsetPort)
+                    convertedPort = PortLogic.DeterminePortByProtocol(port);
+                if (!IPAddress.TryParse(host, out var ip))
+                    request = new ConnectionRequest(null, convertedPort, host);
+                else
+                    request = new ConnectionRequest(ip, convertedPort);
+
+                if (request.Port == PortLogic.UnsetPort || request.Port < 0 || request.Port > ushort.MaxValue) throw new ArgumentException($"The input you provided for the port is not valid, your input: {request.Port}.");
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid input: {input} is nether a valid url nor a host:port or host:protocol.");
+            }
+            return request;
         }
 
         public IPAddress Ip { get; }

--- a/src/Tring/ConnectionRequest.cs
+++ b/src/Tring/ConnectionRequest.cs
@@ -31,6 +31,7 @@ namespace Tring
             Url = url;
             Port = port;
         }
+
         public static ConnectionRequest Parse(string input)
         {
             ConnectionRequest request;

--- a/src/Tring/ConnectionTester.cs
+++ b/src/Tring/ConnectionTester.cs
@@ -44,11 +44,13 @@ namespace Tring
             }
             else if (match.Success)
             {
-                var convertedPort = PortLogic.StringToPort(match.Groups["port"].Value);
+                var host = match.Groups["host"].Value;
+                var port = match.Groups["port"].Value;
+                var convertedPort = PortLogic.StringToPort(port);
                 if (convertedPort == PortLogic.UnsetPort)
-                    convertedPort = PortLogic.DeterminePortByProtocol(match.Groups["port"].Value);
-                if (!IPAddress.TryParse(match.Groups["host"].Value, out var ip))
-                    request = new ConnectionRequest(null, convertedPort, match.Groups["host"].Value);
+                    convertedPort = PortLogic.DeterminePortByProtocol(port);
+                if (!IPAddress.TryParse(host, out var ip))
+                    request = new ConnectionRequest(null, convertedPort, host);
                 else
                     request = new ConnectionRequest(ip, convertedPort);
 

--- a/src/Tring/ConnectionTester.cs
+++ b/src/Tring/ConnectionTester.cs
@@ -62,7 +62,7 @@ namespace Tring
             }
         }
 
-        public async Task<ConnectionResult> TryConnect()
+        public ConnectionResult TryConnect()
         {
             ConnectionStatus Connection, DNS;
             DNS = ConnectionStatus.Untried;

--- a/src/Tring/ConnectionTester.cs
+++ b/src/Tring/ConnectionTester.cs
@@ -71,6 +71,7 @@ namespace Tring
                 return new ConnectionResult(_request, DNS, Connection, Ping, localInterface, 0, PingTimeMs);
             }
         }
+
         public static (ConnectionStatus status, long timeInMs) PingHost(IPAddress ip)
         {
             using (var ping = new Ping())

--- a/src/Tring/ConnectionTester.cs
+++ b/src/Tring/ConnectionTester.cs
@@ -21,6 +21,7 @@ using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Tring
 {
@@ -59,7 +60,7 @@ namespace Tring
             }
         }
 
-        public ConnectionResult TryConnect()
+        public async Task<ConnectionResult> TryConnect()
         {
             ConnectionStatus Connection, DNS;
             DNS = ConnectionStatus.Untried;

--- a/src/Tring/ConnectionTester.cs
+++ b/src/Tring/ConnectionTester.cs
@@ -20,46 +20,19 @@ using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Tring
 {
     internal class ConnectionTester
     {
         private readonly TimeSpan waitTime = TimeSpan.FromSeconds(1);
-        
-        public static readonly Regex SplitFormat = new Regex(@"^(?<host>.*):(?<port>\w+)$");
+
         public enum ConnectionStatus { Succes, TimeOut, Refused, Untried };
-        public ConnectionRequest request;
+        private ConnectionRequest _request;
 
-        public ConnectionTester(string input)
+        public ConnectionTester(ConnectionRequest request)
         {
-            request = new ConnectionRequest();
-            var match = SplitFormat.Match(input);
-            var uriCreated = Uri.TryCreate(input, UriKind.Absolute, out var uri);
-            if(uriCreated && !string.IsNullOrEmpty(uri.DnsSafeHost))
-            {
-                request = new ConnectionRequest(null, uri.Port, uri.DnsSafeHost);
-            }
-            else if (match.Success)
-            {
-                var host = match.Groups["host"].Value;
-                var port = match.Groups["port"].Value;
-                var convertedPort = PortLogic.StringToPort(port);
-                if (convertedPort == PortLogic.UnsetPort)
-                    convertedPort = PortLogic.DeterminePortByProtocol(port);
-                if (!IPAddress.TryParse(host, out var ip))
-                    request = new ConnectionRequest(null, convertedPort, host);
-                else
-                    request = new ConnectionRequest(ip, convertedPort);
-
-                if (request.Port == PortLogic.UnsetPort || request.Port < 0 || request.Port > ushort.MaxValue) throw new ArgumentException($"The input you provided for the port is not valid, your input: {request.Port}.");
-            }
-            else
-            {
-                throw new ArgumentException($"Invalid input: {input} is nether a valid url nor a host:port or host:protocol.");
-            }
+            _request = request;
         }
 
         public ConnectionResult TryConnect()
@@ -68,34 +41,34 @@ namespace Tring
             DNS = ConnectionStatus.Untried;
             Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             IAsyncResult result;
-            if (request.Ip == null)
+            if (_request.Ip == null)
             {
-                DNS = DnsLookup(request.Url, out var ip);
-                request = new ConnectionRequest(ip, request.Port, request.Url);
+                DNS = DnsLookup(_request.Url, out var ip);
+                _request = new ConnectionRequest(ip, _request.Port, _request.Url);
                 if (DNS != ConnectionStatus.Succes)
-                    return new ConnectionResult(request, DNS);
+                    return new ConnectionResult(_request, DNS);
             }
             var watch = System.Diagnostics.Stopwatch.StartNew();
-            result = socket.BeginConnect(request.Ip, request.Port, null, null);
+            result = socket.BeginConnect(_request.Ip, _request.Port, null, null);
             bool connectionSuccess = result.AsyncWaitHandle.WaitOne(waitTime);
-            var localInterface = GetLocalPath(request.Ip, socket);
+            var localInterface = GetLocalPath(_request.Ip, socket);
             if (socket.Connected)
             {
                 watch.Stop();
                 socket.EndConnect(result);
                 var connectionTimeMs = watch.ElapsedMilliseconds;
                 Connection = ConnectionStatus.Succes;
-                return new ConnectionResult(request, DNS, Connection, ConnectionStatus.Untried, localInterface, connectionTimeMs);
+                return new ConnectionResult(_request, DNS, Connection, ConnectionStatus.Untried, localInterface, connectionTimeMs);
             }
             else
             {
                 socket.Close();
-                var (Ping, PingTimeMs) = PingHost(request.Ip);
+                var (Ping, PingTimeMs) = PingHost(_request.Ip);
                 if (connectionSuccess)
                     Connection = ConnectionStatus.Refused;
                 else
                     Connection = ConnectionStatus.TimeOut;
-                return new ConnectionResult(request, DNS, Connection, Ping, localInterface, 0, PingTimeMs);
+                return new ConnectionResult(_request, DNS, Connection, Ping, localInterface, 0, PingTimeMs);
             }
         }
         public static (ConnectionStatus status, long timeInMs) PingHost(IPAddress ip)

--- a/src/Tring/OutputPrinter.cs
+++ b/src/Tring/OutputPrinter.cs
@@ -16,6 +16,7 @@
 //along with Tring.If not, see<https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 
 namespace Tring
 {
@@ -34,16 +35,30 @@ namespace Tring
             PrintHostName(status.Request.Url);
         }
 
+        public static void PrintLogEntry(ConnectionResult[] results)
+        {
+            foreach(ConnectionResult connection in results)
+            {
+                PrintTime(connection.TimeStamp, connection.TimeStamp);
+                PrintRequest(connection);
+                PrintResult(connection.Connect, connection.ConnectionTimeMs);
+                PrintPing(connection.PingResult, connection.PingTimeMs);
+                PrintLocalInterface(connection.LocalInterface);
+                PrintProtocol(connection.Request.Port);
+                PrintHostName(connection.Request.Url);
+            }
+        }
+
         public static void PrintTable()
         {
-            Console.WriteLine("| Time              | IP              | Port  | Connect | Ping    | Local Interface | Protocol | Hostname  ");
+            Console.WriteLine("| Time              | IP              | Port  | Connect | Ping    | Local Interface | Protocol | Hostname");
             // example output  | 20:22:22-20:23:33 | 100.100.203.104 | 80222 | Timeout | 1000 ms | 111.111.111.111 | https    | google.com
         }
 
-        public static void ResetPrintLine()
+        public static void ResetPrintLine(int lines = 0)
         {
             if (!Console.IsOutputRedirected)
-                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.SetCursorPosition(0, Console.CursorTop - lines);
         }
 
         public static void HideCursor()

--- a/src/Tring/OutputPrinter.cs
+++ b/src/Tring/OutputPrinter.cs
@@ -38,13 +38,7 @@ namespace Tring
         {
             for(int i= 0; i< currentResults.Length; i++)
             {
-                PrintTime(oldResults[i].TimeStamp, currentResults[i].TimeStamp);
-                PrintRequest(currentResults[i]);
-                PrintResult(currentResults[i].Connect, currentResults[i].ConnectionTimeMs);
-                PrintPing(currentResults[i].PingResult, currentResults[i].PingTimeMs);
-                PrintLocalInterface(currentResults[i].LocalInterface);
-                PrintProtocol(currentResults[i].Request.Port);
-                PrintHostName(currentResults[i].Request.Url);
+                PrintLogEntry(oldResults[i].TimeStamp, currentResults[i]);
             }
         }
 

--- a/src/Tring/OutputPrinter.cs
+++ b/src/Tring/OutputPrinter.cs
@@ -92,6 +92,7 @@ namespace Tring
                     Console.CursorTop++;
             }
         }
+
         public void SetCancelEventHandler(CancellationTokenSource sourceToken, int endLine)
         {
             Console.CancelKeyPress += (sender, args) =>
@@ -100,10 +101,12 @@ namespace Tring
                 CleanUpConsole(endLine);
             };
         }
+
         private void PrintProtocol(int port)
         {
             Console.Write($"{PortLogic.DetermineProtocolByPort(port),-8} | ");
         }
+
         private void PrintHostName(string url)
         {
             Console.ResetColor();

--- a/src/Tring/OutputPrinter.cs
+++ b/src/Tring/OutputPrinter.cs
@@ -16,7 +16,6 @@
 //along with Tring.If not, see<https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 
 namespace Tring
 {
@@ -35,17 +34,17 @@ namespace Tring
             PrintHostName(status.Request.Url);
         }
 
-        public static void PrintLogEntry(ConnectionResult[] results)
+        public static void PrintLogEntry(ConnectionResult[] oldResults, ConnectionResult[] currentResults)
         {
-            foreach(ConnectionResult connection in results)
+            for(int i= 0; i< currentResults.Length; i++)
             {
-                PrintTime(connection.TimeStamp, connection.TimeStamp);
-                PrintRequest(connection);
-                PrintResult(connection.Connect, connection.ConnectionTimeMs);
-                PrintPing(connection.PingResult, connection.PingTimeMs);
-                PrintLocalInterface(connection.LocalInterface);
-                PrintProtocol(connection.Request.Port);
-                PrintHostName(connection.Request.Url);
+                PrintTime(oldResults[i].TimeStamp, currentResults[i].TimeStamp);
+                PrintRequest(currentResults[i]);
+                PrintResult(currentResults[i].Connect, currentResults[i].ConnectionTimeMs);
+                PrintPing(currentResults[i].PingResult, currentResults[i].PingTimeMs);
+                PrintLocalInterface(currentResults[i].LocalInterface);
+                PrintProtocol(currentResults[i].Request.Port);
+                PrintHostName(currentResults[i].Request.Url);
             }
         }
 

--- a/src/Tring/PortLogic.cs
+++ b/src/Tring/PortLogic.cs
@@ -23,6 +23,7 @@ namespace Tring
     internal class PortLogic
     {
         public const int UnsetPort = -1;
+
         public static readonly Dictionary<string, int> PortByProtocols = new Dictionary<string, int>
         {
             ["ftp"] = 21,
@@ -42,6 +43,7 @@ namespace Tring
             ["sql"] = 1433,
             ["rdp"] = 3389
         };
+
         public static int StringToPort(string toConvert)
         {
             if (!int.TryParse(toConvert, out var toReturn))
@@ -50,6 +52,7 @@ namespace Tring
             }
             return toReturn;
         }
+
         public static int DeterminePortByProtocol(string protocol)
         {
             if (PortByProtocols.ContainsKey(protocol))
@@ -57,6 +60,7 @@ namespace Tring
             else
                 return UnsetPort;
         }
+
         public static string DetermineProtocolByPort(int port) => PortByProtocols.FirstOrDefault(pair => pair.Value == port).Key ?? "";
     }
 }

--- a/src/Tring/Program.cs
+++ b/src/Tring/Program.cs
@@ -130,6 +130,7 @@ namespace Tring
                 }
             });
         }
+
         private static async Task CheckIfEscPress(CancellationTokenSource tokenSource)
         {
             await Task.Run(async () =>

--- a/src/Tring/Program.cs
+++ b/src/Tring/Program.cs
@@ -44,7 +44,7 @@ namespace Tring
                         SingleConnect(optionWatch.Value() == "on", new ConnectionTester(arguments.Values[0]));
                         break;
                     default:
-                        await MultiConnect(optionWatch.Value() == "on", arguments.Values);
+                        MultiConnect(optionWatch.Value() == "on", arguments.Values);
                         break;
                 }
                 return 0;
@@ -67,7 +67,7 @@ namespace Tring
             return await connectionTester.TryConnect();
         }
 
-        private static async Task MultiConnect(bool watchMode, List<string> connections)
+        private static Task MultiConnect(bool watchMode, List<string> connections)
         {
             var connectors = new List<ConnectionTester>();
             var results = new ConnectionResult[connections.Count];
@@ -80,10 +80,10 @@ namespace Tring
             while (true)
             {
                 var watch = System.Diagnostics.Stopwatch.StartNew();
-                for (int i= 0; i< connectors.Count;i++)
+                Parallel.For(0, connectors.Count, async (i) =>
                 {
-                    results[i] = await Connect(connectors[i]); 
-                }
+                    results[i] = await Connect(connectors[i]);
+                });
                 OutputPrinter.PrintLogEntry(results);
                 if (!watchMode)
                     break;
@@ -99,6 +99,7 @@ namespace Tring
                 }
             }
             OutputPrinter.CleanUp();
+            return null;
         }
 
         private static void SingleConnect(bool watchMode, ConnectionTester connectionTester)

--- a/src/Tring/Program.cs
+++ b/src/Tring/Program.cs
@@ -34,7 +34,7 @@ namespace Tring
             var arguments = app.Argument("arguments", "Enter the ip or url you wish to test.",true);
             var optionWatch = app.Option("-w|--watch", "Set the application to continually check the connection at the specified interval in seconds.", CommandOptionType.NoValue);
 
-            app.OnExecute(() =>
+            app.OnExecute(async () =>
             {
                 switch (arguments.Values.Count)
                 {
@@ -44,7 +44,7 @@ namespace Tring
                         SingleConnect(optionWatch.Value() == "on", new ConnectionTester(arguments.Values[0]));
                         break;
                     default:
-                        MultiConnect(optionWatch.Value() == "on", arguments.Values);
+                        await MultiConnect(optionWatch.Value() == "on", arguments.Values);
                         break;
                 }
                 return 0;
@@ -64,10 +64,10 @@ namespace Tring
 
         internal static async Task<ConnectionResult> Connect(ConnectionTester connectionTester)
         {
-            return connectionTester.TryConnect();
+            return await connectionTester.TryConnect();
         }
 
-        private static async void MultiConnect(bool watchMode, List<string> connections)
+        private static async Task MultiConnect(bool watchMode, List<string> connections)
         {
             var connectors = new List<ConnectionTester>();
             var results = new ConnectionResult[connections.Count];
@@ -88,7 +88,7 @@ namespace Tring
                 if (!watchMode)
                     break;
                 OutputPrinter.HideCursor();
-                if (Console.KeyAvailable && Console.ReadKey().Key == ConsoleKey.Escape)
+                if (ExitAplication)
                 {
                     break;
                 }
@@ -110,7 +110,7 @@ namespace Tring
             while (true)
             {
                 var watch = System.Diagnostics.Stopwatch.StartNew();
-                var newResult = connectionTester.TryConnect();
+                var newResult = connectionTester.TryConnect().Result;
                 if (result?.IsEquivalent(newResult) ?? false)
                 {
                     if (!Console.IsOutputRedirected)
@@ -126,7 +126,7 @@ namespace Tring
                 if (!watchMode)
                     break;
                 OutputPrinter.HideCursor();
-                if (Console.KeyAvailable && Console.ReadKey().Key == ConsoleKey.Escape)
+                if (ExitAplication)
                 {
                     break;
                 }
@@ -137,5 +137,7 @@ namespace Tring
             }
             OutputPrinter.CleanUp();
         }
+
+        private static bool ExitAplication => Console.KeyAvailable && Console.ReadKey().Key == ConsoleKey.Escape;
     }
 }

--- a/src/Tring/Properties/launchSettings.json
+++ b/src/Tring/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tring": {
       "commandName": "Project",
-      "commandLineArgs": "google.nl:20 google.nl:21 google.nl:22 google.nl:23 google.nl:24 -w"
+      "commandLineArgs": "google.nl:20  10.100.100.22:80 google.nl:21 google.nl:22 google.nl:23 google.nl:24 10.100.100.1:80  10.100.100.0:80  -w"
     }
   }
 }

--- a/src/Tring/Properties/launchSettings.json
+++ b/src/Tring/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tring": {
       "commandName": "Project",
-      "commandLineArgs": "http://www.google.nl google.nl:80 google.nl:https -w"
+      "commandLineArgs": "google.nl:20 google.nl:21 google.nl:22 google.nl:23 google.nl:24 -w"
     }
   }
 }

--- a/src/Tring/Properties/launchSettings.json
+++ b/src/Tring/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tring": {
       "commandName": "Project",
-      "commandLineArgs": "google.nl:20  10.100.100.22:80 google.nl:21 google.nl:22 google.nl:23 google.nl:24 10.100.100.1:80  10.100.100.0:80  -w"
+      "commandLineArgs": "google.nl:20  10.100.100.22:80 google.nl:21 google.nl:22 google.nl:23 google.nl:24 10.100.100.1:80  10.100.100.0:80 -w"
     }
   }
 }

--- a/src/Tring/Properties/launchSettings.json
+++ b/src/Tring/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Tring": {
       "commandName": "Project",
-      "commandLineArgs": "http://www.google.nl -w"
+      "commandLineArgs": "http://www.google.nl google.nl:80 google.nl:https -w"
     }
   }
 }

--- a/test/TringTests/ConnectionTesterCreation.cs
+++ b/test/TringTests/ConnectionTesterCreation.cs
@@ -23,48 +23,48 @@ using Xunit;
 
 namespace TringTests
 {
-    public class ConnectionTesterCreation
+    public class ConnectionRequestCreation
     {
         [Theory]
         [InlineData("http://google.nl")]
         [InlineData("http://google.nl/test")]
         [InlineData("http://google.nl:80")]
         [InlineData("http://google.nl:80/test")]
-        public void CreateConnectionTesterURL(string host)
+        public void CreateConnectionRequestBasedOnURL(string host)
         {
-            var tester = new ConnectionTester(host);
-            tester.request.Url.Should().Be("google.nl");
-            tester.request.Port.Should().Be(80);
+            var request = ConnectionRequest.Parse(host);
+            request.Url.Should().Be("google.nl");
+            request.Port.Should().Be(80);
         }
         [Theory]
         [InlineData("google.nl:80")]
         [InlineData("google.nl:http")]
-        public void CreateConnectionTesterPartialURL(string host)
+        public void CreateConnectionRequestPartialURL(string host)
         {
-            var tester = new ConnectionTester(host);
-            tester.request.Url.Should().Be("google.nl");
-            tester.request.Port.Should().Be(80);
+            var request = ConnectionRequest.Parse(host);
+            request.Url.Should().Be("google.nl");
+            request.Port.Should().Be(80);
         }
 
         [Theory]
         [InlineData("1.1.1.1:80")]
         [InlineData("1.1.1.1:http")]
-        public void CreateConnectionTesterIP(string host)
+        public void CreateConnectionRequestIP(string host)
         {
-            var tester = new ConnectionTester(host);
-            tester.request.Ip.Should().Be(IPAddress.Parse("1.1.1.1"));
-            tester.request.Port.Should().Be(80);
+            var request = ConnectionRequest.Parse(host);
+            request.Ip.Should().Be(IPAddress.Parse("1.1.1.1"));
+            request.Port.Should().Be(80);
         }
 
         [Theory]
         [InlineData("")]
         [InlineData("1.1.1.1")]
         [InlineData("1.1.1.1:nonsense")]
-        public void CreateConnectionTesterIncorrectly(string host)
+        public void CreateConnectionRequestIncorrectly(string host)
         {
             Action action = () =>
             {
-                _ = new ConnectionTester(host);
+                _ = ConnectionRequest.Parse(host);
             };
             action.Should().Throw<Exception>();
         }

--- a/test/TringTests/ConnectionTesterCreation.cs
+++ b/test/TringTests/ConnectionTesterCreation.cs
@@ -36,6 +36,7 @@ namespace TringTests
             request.Url.Should().Be("google.nl");
             request.Port.Should().Be(80);
         }
+
         [Theory]
         [InlineData("google.nl:80")]
         [InlineData("google.nl:http")]


### PR DESCRIPTION
This adds support for connecting to multiple hosts by using a space separated format.
Example: tring google.nl:80 8.8.8.8:80 somewebsite.com:http https://google.nl --watch
In watch mode this feature will overwrite the last result if a change occurs so the order is preserved and its hopefully easy to read.  